### PR TITLE
Fix plot labels and size bar ordering

### DIFF
--- a/R/ship_of_theseus.R
+++ b/R/ship_of_theseus.R
@@ -72,6 +72,7 @@ ShipOfTheseus <- R6::R6Class(
     #' @importFrom tidyr replace_na
     initialize = function(data1, data2, outcome, labels, ylab, digits, text_size) {
       outcome <- rlang::quo_squash(outcome) |> rlang::as_string()
+      labels <- as.character(labels)
 
       data1 <- private$prepare_input_data(data1, outcome)
       data2 <- private$prepare_input_data(data2, outcome)
@@ -359,10 +360,14 @@ ShipOfTheseus <- R6::R6Class(
         bind_rows(result)|>
         mutate(contrib = round(contrib * 100, digits = private$digits))
 
+      n_bars <- nrow(result) + 1L
       p <- waterfall(
-        result, calc_total = TRUE, total_axis_text = labels[2],
+        values = result$contrib, labels = result$items,
+        calc_total = TRUE, total_axis_text = n_bars,
         total_rect_text_color = "black", total_rect_color = "#00BFC4", 
         rect_text_size = private$text_size)
+      scale_x <- p@scales$get_scales("x")
+      scale_x$labels <- c(result$items, labels[2])
       
       if (is.null(main_item) & is.null(bar_max_value)) {
         data_max <- result |> tail(-1) |> 
@@ -378,8 +383,7 @@ ShipOfTheseus <- R6::R6Class(
         n_max <- data_size |> filter(n == max(n)) |> pull(n) |> max()
       }
     
-      data_size <- tibble(x = c(1L, seq_along(names) + 1L, labels[2])) |>
-        arrange(x) |>
+      data_size <- tibble(x = as.character(seq_len(n_bars))) |>
         mutate(items = c(labels[1], names, labels[2])) |>
         left_join(data_size, by = "items") |>
         tidyr::replace_na(list(n = 0L)) |>
@@ -445,13 +449,17 @@ ShipOfTheseus <- R6::R6Class(
 
       colors <- if_else(result$contrib > 0, "#F8766D", "#00BFC4")
       colors[1] <- "#00BFC4"
+      n_bars <- nrow(result) + 1L
       p <- waterfall(
-        result, calc_total = TRUE, total_axis_text = labels[1],
+        values = result$contrib, labels = result$items,
+        calc_total = TRUE, total_axis_text = n_bars,
         total_rect_text_color = "black", fill_colours = colors,
         fill_by_sign = FALSE, total_rect_color = "#00BFC4",
         rect_text_size = private$text_size) +
         coord_flip()
-
+      scale_x <- p@scales$get_scales("x")
+      scale_x$labels <- c(result$items, labels[1])
+      
       reverse_sign <- function(x) {
         x <- str_replace(x, "\u2212", "-")
         x <- -as.numeric(x)
@@ -484,8 +492,7 @@ ShipOfTheseus <- R6::R6Class(
         n_max <- data_size |> filter(n == max(n)) |> pull(n) |> max()
       }
 
-      data_size <- tibble(x = c(1L, seq_along(names) + 1L, labels[1])) |>
-        arrange(x) |>
+      data_size <- tibble(x = as.character(seq_len(n_bars))) |>
         mutate(items = c(labels[2], names, labels[1])) |>
         left_join(data_size, by = "items") |>
         tidyr::replace_na(list(n = 0L)) |>

--- a/tests/testthat/test-plot-waterfalls-compatibility.R
+++ b/tests/testthat/test-plot-waterfalls-compatibility.R
@@ -1,4 +1,4 @@
-make_plot_test_ship <- function() {
+make_plot_test_ship <- function(labels = c("Before", "After")) {
   data1 <- data.frame(
     group = rep(c("A", "B"), each = 4L),
     y = c(1, 1, 1, 0, 1, 0, 0, 0)
@@ -6,6 +6,20 @@ make_plot_test_ship <- function() {
   data2 <- data.frame(
     group = rep(c("A", "B"), each = 4L),
     y = c(1, 0, 0, 0, 0, 0, 0, 0)
+  )
+
+  create_ship(data1, data2, y = y, labels = labels)
+}
+
+make_many_item_plot_test_ship <- function() {
+  items <- paste0("item", seq_len(9L))
+  data1 <- data.frame(
+    group = rep(items, times = seq_along(items)),
+    y = rep(c(0, 1), length.out = sum(seq_along(items)))
+  )
+  data2 <- data.frame(
+    group = rep(items, times = rev(seq_along(items))),
+    y = rep(c(1, 0), length.out = sum(seq_along(items)))
   )
 
   create_ship(data1, data2, y = y, labels = c("Before", "After"))
@@ -39,18 +53,103 @@ expect_valid_size_bars <- function(size_bar_data, is_flip = FALSE) {
   expect_equal(actual, expected)
 }
 
-test_that("plot() retains subgroup size bars with waterfalls 1.1.4", {
+expect_size_bars_in_item_order <- function(size_bar_data, is_flip = FALSE) {
+  items <- paste0("item", seq_len(9L))
+  n_items <- length(items)
+  first_label <- "Before"
+  last_label <- "After"
+  before_size <- seq_len(9L) * 10
+  after_size <- rev(seq_len(9L)) * 10
+
+  if (is_flip) {
+    items <- rev(items)
+    first_label <- "After"
+    last_label <- "Before"
+    before_size <- rev(before_size)
+    after_size <- rev(after_size)
+  }
+
+  actual <- size_bar_data |>
+    mutate(x = as.character(x)) |>
+    select(x, items, n, type)
+
+  expected <- tibble(
+    x = c(
+      "1",
+      rep(as.character(seq_along(items) + 1L), each = 2L),
+      as.character(n_items + 2L)
+    ),
+    items = c(first_label, rep(items, each = 2L), last_label),
+    n = c(0, as.vector(rbind(before_size, after_size)), 0),
+    type = factor(
+      c(NA, rep(c("Before", "After"), times = n_items), NA),
+      levels = if (is_flip) c("After", "Before") else c("Before", "After")
+    )
+  )
+
+  expect_equal(actual, expected)
+}
+
+test_that("plot() retains axis labels with waterfalls 1.1.4", {
   ship <- make_plot_test_ship()
 
-  size_bar_data <- ship$plot(group) |> get_size_bar_data()
+  plot <- ship$plot(group)
+  panel <- ggplot2::ggplot_build(plot)$layout$panel_params[[1]]
 
-  expect_valid_size_bars(size_bar_data)
+  expect_equal(panel$x$get_labels(), c("Before", "A", "B", "After"))
 })
 
-test_that("plot_flip() retains subgroup size bars with waterfalls 1.1.4", {
+test_that("plot_flip() retains axis labels with waterfalls 1.1.4", {
   ship <- make_plot_test_ship()
 
-  size_bar_data <- ship$plot_flip(group) |> get_size_bar_data()
+  plot <- ship$plot_flip(group)
+  panel <- ggplot2::ggplot_build(plot)$layout$panel_params[[1]]
 
-  expect_valid_size_bars(size_bar_data, is_flip = TRUE)
+  expect_equal(panel$y$get_labels(), c("After", "B", "A", "Before"))
+})
+
+test_that("plot() supports numeric group labels", {
+  ship <- make_plot_test_ship(labels = c(1, 2))
+
+  plot <- ship$plot(group)
+  panel <- ggplot2::ggplot_build(plot)$layout$panel_params[[1]]
+
+  expect_equal(panel$x$get_labels(), c("1", "A", "B", "2"))
+})
+
+test_that("plot_flip() supports numeric group labels", {
+  ship <- make_plot_test_ship(labels = c(1, 2))
+
+  plot <- ship$plot_flip(group)
+  panel <- ggplot2::ggplot_build(plot)$layout$panel_params[[1]]
+
+  expect_equal(panel$y$get_labels(), c("2", "B", "A", "1"))
+})
+
+test_that("plot() keeps size bars ordered with nine subgroups", {
+  ship <- make_many_item_plot_test_ship()
+  items <- paste0("item", seq_len(9L))
+
+  size_bar_data <- ship$plot(
+    group,
+    levels = items,
+    bar_max_value = 90
+  ) |>
+    get_size_bar_data()
+
+  expect_size_bars_in_item_order(size_bar_data)
+})
+
+test_that("plot_flip() keeps size bars ordered with nine subgroups", {
+  ship <- make_many_item_plot_test_ship()
+  items <- paste0("item", seq_len(9L))
+
+  size_bar_data <- ship$plot_flip(
+    group,
+    levels = items,
+    bar_max_value = 90
+  ) |>
+    get_size_bar_data()
+
+  expect_size_bars_in_item_order(size_bar_data, is_flip = TRUE)
 })


### PR DESCRIPTION
## Summary

- Support numeric values in the `labels` argument of `create_ship()`.
- Prevent plot labels from conflicting with the internal x-axis positions used by `waterfalls`.
- Preserve size-bar ordering when plotting nine or more subgroups.
- Apply the fixes to both `plot()` and `plot_flip()`.

## Background

`waterfalls` uses character representations of sequential numbers as internal x-axis positions.

Passing numeric labels such as `c(1, 2)` could therefore conflict with those internal positions. In addition, sorting character x positions caused values such as `"10"` to appear before `"2"` when nine or more subgroups were plotted.

## Changes

- Normalize `labels` to character values during initialization.
- Use sequential internal positions for all waterfall bars, including the total bar.
- Set the displayed axis labels separately from the internal positions.
- Remove character-based sorting of the size-bar positions.
- Add regression tests covering:
  - axis labels in `plot()` and `plot_flip()`
  - numeric group labels
  - size-bar ordering with nine subgroups

## Testing

The plot compatibility test suite passes for both plot orientations.